### PR TITLE
Update host storage relationship to include file shares

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/provision/cloning.rb
@@ -1,5 +1,5 @@
 module ManageIQ::Providers::Microsoft::InfraManager::Provision::Cloning
-  MT_POINT_REGEX = %r{file://.*/([A-Z][:].*)}i
+  MT_POINT_REGEX = %r{file://.*?/(.*)}i
 
   def log_clone_options(clone_options)
     _log.info("Provisioning [#{source.name}] to [#{clone_options[:name]}]")

--- a/app/models/manageiq/providers/microsoft/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/refresh_parser.rb
@@ -290,9 +290,15 @@ module ManageIQ::Providers::Microsoft
     end
 
     def process_host_storages(properties)
-      properties['DiskVolumes'].collect do |dv|
+      disk_volumes = properties['DiskVolumes'].collect do |dv|
         @data_index.fetch_path(:storages, dv['ID'])
       end.compact
+
+      file_shares = properties['RegisteredStorageFileShares'].collect do |fs|
+        @data_index.fetch_path(:storages, fs['ID'])
+      end.compact
+
+      disk_volumes + file_shares
     end
 
     def map_mount_point_to_datastore(properties)

--- a/spec/models/manageiq/providers/microsoft/infra_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/microsoft/infra_manager/provision_spec.rb
@@ -12,6 +12,25 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Provision do
     )
   end
 
+  let(:regex) { ManageIQ::Providers::Microsoft::InfraManager::Provision::Cloning::MT_POINT_REGEX }
+
+  context "MT_POINT_REGEX" do
+    it "matches a storage name with a drive letter" do
+      string = "file://foo.cfme-qe.redhat.com/J:/"
+      expect(string.scan(regex).flatten.first).to eql("J:/")
+    end
+
+    it "matches a storage name with a drive letter and path" do
+      string = "file://foo.cfme-qe.redhat.com/C:/ClusterStorage/netapp_crud_vol"
+      expect(string.scan(regex).flatten.first).to eql("C:/ClusterStorage/netapp_crud_vol")
+    end
+
+    it "matches a storage name without a drive letter" do
+      string = "file://foo123.redhat.com///clusterstore.xx-yy-redhat.com/cdrive"
+      expect(string.scan(regex).flatten.first).to eql("//clusterstore.xx-yy-redhat.com/cdrive")
+    end
+  end
+
   context "A new provision request," do
     before(:each) do
       @os = OperatingSystem.new(:product_name => 'Microsoft Windows')

--- a/spec/models/manageiq/providers/microsoft/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/microsoft/infra_manager/refresher_spec.rb
@@ -71,7 +71,7 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Refresher do
     expect(@ems.ems_clusters.size).to eq(1)
     expect(@ems.resource_pools.size).to eq(0)
 
-    expect(@ems.storages.size).to eq(11)
+    expect(@ems.storages.size).to eq(13)
     expect(@ems.hosts.size).to eq(3)
     expect(@ems.vms_and_templates.size).to eq(71)
     expect(@ems.vms.size).to eq(46)


### PR DESCRIPTION
Followup to #2. This establishes the relationship between the hosts and storages for file shares.

I also had to modify the MT_POINT_REGEX because the fileshares don't have a drive letter.