### PR TITLE
Disable the reset option in the UI unless the VM is powered on

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/vm.rb
@@ -3,7 +3,10 @@ class ManageIQ::Providers::Microsoft::InfraManager::Vm < ManageIQ::Providers::In
 
   supports_not :migrate, :reason => _("Migrate operation is not supported.")
   supports_not :publish
-  supports     :reset
+
+  supports :reset do
+    unsupported_reason_add(:reset, _('The VM is not powered on')) unless current_state == 'on'
+  end
 
   POWER_STATES = {
     "Running"  => "on",

--- a/spec/models/manageiq/providers/microsoft/infra_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/microsoft/infra_manager/vm_spec.rb
@@ -30,4 +30,23 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Vm do
       expect(@proxies[:proxies].first).to eq('default')
     end
   end
+
+  context "reset" do
+    let(:vm) { ManageIQ::Providers::Microsoft::InfraManager::Vm.new }
+    let(:powered_on) { "Running" }
+    let(:powered_off) { "PowerOff" }
+
+    it "is available when powered on" do
+      vm.update_attributes(:raw_power_state => powered_on)
+      expect(vm.current_state).to eql('on')
+      expect(vm.supports_reset?).to be_truthy
+    end
+
+    it "is not available when powered off" do
+      vm.update_attributes(:raw_power_state => powered_off)
+      expect(vm.current_state).to eql('off')
+      expect(vm.supports_reset?).to be_falsy
+      expect(vm.unsupported_reason(:reset)).to eql('The VM is not powered on')
+    end
+  end
 end


### PR DESCRIPTION
This utilizes the `SupportsFeatureMixin` to disable the reset option for an instance unless the VM is powered on, which the UI hooks into.

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1455225