### PR TITLE
Fix logger for powershell specs

### DIFF
--- a/spec/models/manageiq/providers/microsoft/infra_manager/powershell_spec.rb
+++ b/spec/models/manageiq/providers/microsoft/infra_manager/powershell_spec.rb
@@ -40,7 +40,7 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Powershell do
     before(:each) do
       $original_scvmm_log = $scvmm_log.clone
       @log_file = ManageIQ::Providers::Scvmm::Engine.root.join("spec", "tools", "scvmm_data", "powershell.log")
-      $scvmm_log = Vmdb::Loggers::MirroredLogger.new(@log_file, "<POWERSHELL>")
+      $scvmm_log = VMDBLogger.new(@log_file, :error, "<POWERSHELL>")
     end
 
     after(:each) do


### PR DESCRIPTION
Apparently the MirroredLogger class was removed from core, so this updates the specs to just use a plain VMDBLogger.