### PR TITLE
Use try_decrypt on password in build_connect_params

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager.rb
@@ -137,7 +137,7 @@ class ManageIQ::Providers::Microsoft::InfraManager < ManageIQ::Providers::InfraM
   def build_connect_params(options)
     connect_params  = {
       :user         => options[:user]     || authentication_userid(options[:auth_type]),
-      :password     => options[:password] || authentication_password(options[:auth_type]),
+      :password     => MiqPassword.try_decrypt(options[:password]) || authentication_password(options[:auth_type]),
       :endpoint     => options[:endpoint],
       :disable_sspi => true
     }


### PR DESCRIPTION
Validation of credentials in the UI will soon be done on the queue (see: https://github.com/ManageIQ/manageiq-ui-classic/pull/1580). This will require us to encrypt the passwords. By adding `MiqPassword.try_decrypt` when setting the password in `build_connect_params`, both encrypted and unencrypted passwords will now be supported.