### PR TITLE
Force array context for VMs, hosts, vnets and images

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager/ps_scripts/get_inventory.ps1
+++ b/app/models/manageiq/providers/microsoft/infra_manager/ps_scripts/get_inventory.ps1
@@ -6,7 +6,7 @@ $ems = Get-SCVMMServer -ComputerName localhost |
   Select @{name='Guid';expression={$_.ManagedComputer.ID -As [string]}},
     @{name='Version';expression={$_.ServerInterfaceVersion -As [string]}}
 
-$vms = Get-SCVirtualMachine -VMMServer localhost -All |
+$vms = @(Get-SCVirtualMachine -VMMServer localhost -All |
   Select -Property BackupEnabled,BiosGuid,ComputerName,CPUCount,CPUType,DataExchangeEnabled,
     HeartbeatEnabled,HostName,ID,LastRestoredCheckpointID,Memory,Name,OperatingSystem,
     OperatingSystemShutdownEnabled,ServerConnection,TimeSynchronizationEnabled,
@@ -17,22 +17,22 @@ $vms = Get-SCVirtualMachine -VMMServer localhost -All |
     % {
       if($_.DVDISO){ $_.DVDISO = @($_.DVDISO); $_ } # Force array context
       else{ $_ }
-    }
+    })
 
-$hosts = Get-SCVMHost -VMMServer localhost |
+$hosts = @(Get-SCVMHost -VMMServer localhost |
   Select -Property CommunicationStateString,CoresPerCPU,DiskVolumes,DVDDriveList,
     HyperVStateString,ID,LogicalProcessorCount,Name,OperatingSystem,OverallState,PhysicalCPUCount,
     ProcessorFamily,ProcessorManufacturer,ProcessorModel,ProcessorSpeed,
     RegisteredStorageFileShares, TotalMemory,
     @{name='HyperVVersionString';expression={$_.HyperVVersion -As [string]}},
     @{name='OperatingSystemVersionString';expression={$_.OperatingSystemVersion -As [string]}},
-    @{name='VirtualizationPlatformString';expression={$_.VirtualizationPlatform -As [string]}}
+    @{name='VirtualizationPlatformString';expression={$_.VirtualizationPlatform -As [string]}})
 
-$vnets = Get-SCVirtualNetwork -VMMServer localhost |
+$vnets = @(Get-SCVirtualNetwork -VMMServer localhost |
   Select -Property ID,Name,LogicalNetworks,VMHostNetworkAdapters,
-    @{name='VMHostName';expression={$_.VMHost.Name -As [string]}}
+    @{name='VMHostName';expression={$_.VMHost.Name -As [string]}})
 
-$images = Get-SCVMTemplate -VMMServer localhost |
+$images = @(Get-SCVMTemplate -VMMServer localhost |
   Select -Property CPUCount,Memory,Name,ID,VirtualHardDisks,VirtualDVDDrives,
     @{name="CPUTypeString";expression={$_.CPUType.Name}},
     @{name="OperatingSystemString";expression={$_.OperatingSystem.Name}},
@@ -40,7 +40,7 @@ $images = Get-SCVMTemplate -VMMServer localhost |
     % {
       if($_.DVDISO){ $_.DVDISO = @($_.DVDISO); $_ } # Force array context
       else{ $_ }
-    }
+    })
 
 $clusters = @(Get-SCVMHostCluster -VMMServer localhost | Select -Property ClusterName,ID,Nodes)
 


### PR DESCRIPTION
Addresses an issue where a single VM, host, vnet or image would not be interpreted in array context, which breaks our refresh parser. Add `@()` forces the issue. We already did this for clusters, and should do it for the other types of resources as well.

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1474404