### PR TITLE
[WIP] Add VM Networks to collected information

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager/ps_scripts/get_inventory.ps1
+++ b/app/models/manageiq/providers/microsoft/infra_manager/ps_scripts/get_inventory.ps1
@@ -44,7 +44,7 @@ $images = @(Get-SCVMTemplate -VMMServer localhost |
 
 $clusters = @(Get-SCVMHostCluster -VMMServer localhost | Select -Property ClusterName,ID,Nodes)
 
-$vmnetworks = @(Get-SCVMNetwork | Select -Property ID,Name,LogicalNetwork)
+$vmnetworks = @(Get-SCVMNetwork | Select -Property ID,Name,LogicalNetwork,VMSubnet)
 
 $hash["ems"] = $ems
 $hash["hosts"] = $hosts

--- a/app/models/manageiq/providers/microsoft/infra_manager/ps_scripts/get_inventory.ps1
+++ b/app/models/manageiq/providers/microsoft/infra_manager/ps_scripts/get_inventory.ps1
@@ -44,12 +44,15 @@ $images = @(Get-SCVMTemplate -VMMServer localhost |
 
 $clusters = @(Get-SCVMHostCluster -VMMServer localhost | Select -Property ClusterName,ID,Nodes)
 
+$vmnetworks = @(Get-SCVMNetwork | Select -Property ID,Name,LogicalNetwork)
+
 $hash["ems"] = $ems
 $hash["hosts"] = $hosts
 $hash["vnets"] = $vnets
 $hash["clusters"] = $clusters
 $hash["images"] = $images
 $hash["vms"] = $vms
+$hash["vmnetworks"] = $vmnetworks
 
 # Maximum depth is 4 due to VMHostNetworkAdapters
 ConvertTo-Json -InputObject $hash -Depth 4 -Compress

--- a/app/models/manageiq/providers/microsoft/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/refresh_parser.rb
@@ -35,6 +35,7 @@ module ManageIQ::Providers::Microsoft
       get_clusters
       get_vms
       get_images
+      get_vm_networks
       create_relationship_tree
       $scvmm_log.info("#{log_header}...Complete")
       @data
@@ -84,6 +85,28 @@ module ManageIQ::Providers::Microsoft
     def get_images
       images = @inventory['images']
       process_collection(images, :vms) { |image| parse_image(image) }
+    end
+
+    def get_vm_networks
+      vm_networks = @inventory['vmnetworks']
+      process_collection(vm_networks, :guest_devices) { |vm_network| parse_vm_network(vm_network) }
+    end
+
+    def parse_vm_network(vm_network)
+      logical_network = vm_network['LogicalNetwork']
+      uid = vm_network['ID']
+
+      new_result = {
+        :ems_ref      => uid,
+        :device_name  => vm_network['Name'],
+        :device_type  => 'vmnetwork',
+        :lan          => {
+          :name    => logical_network['Name'],
+          :uid_ems => logical_network['ID']
+        }
+      }
+
+      return uid, new_result
     end
 
     def parse_storage_fileshare(volume)

--- a/app/models/manageiq/providers/microsoft/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/refresh_parser.rb
@@ -31,6 +31,7 @@ module ManageIQ::Providers::Microsoft
       get_ems
       get_datastores
       get_storage_fileshares
+      get_switches
       get_hosts
       get_clusters
       get_vms
@@ -90,6 +91,26 @@ module ManageIQ::Providers::Microsoft
     def get_vm_networks
       vm_networks = @inventory['vmnetworks']
       process_collection(vm_networks, :guest_devices) { |vm_network| parse_vm_network(vm_network) }
+    end
+
+    def get_switches
+      switches = @inventory['vnets']
+      process_collection(switches, :switches) { |switch| parse_switch(switch) }
+    end
+
+    # TODO: This was added in order to properly support VM networks. There is
+    # some overlap with the parse_host method. We should clean that up.
+    #
+    def parse_switch(switch)
+      uid = switch['ID']
+
+      new_result = {
+        :uid_ems => uid,
+        :name    => switch['Name'],
+        :lans    => process_logical_networks(switch['LogicalNetworks'])
+      }
+
+      return uid, new_result
     end
 
     def parse_vm_network(vm_network)

--- a/app/models/manageiq/providers/microsoft/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/refresh_parser.rb
@@ -31,7 +31,6 @@ module ManageIQ::Providers::Microsoft
       get_ems
       get_datastores
       get_storage_fileshares
-      get_switches
       get_hosts
       get_clusters
       get_vms
@@ -90,55 +89,45 @@ module ManageIQ::Providers::Microsoft
 
     def get_vm_networks
       vm_networks = @inventory['vmnetworks']
-      process_collection(vm_networks, :guest_devices) { |vm_network| parse_vm_network(vm_network) }
-    end
-
-    def get_switches
-      switches = @inventory['vnets']
-      process_collection(switches, :switches) { |switch| parse_switch(switch) }
-    end
-
-    # TODO: This was added in order to properly support VM networks. There is
-    # some overlap with the parse_host method. We should clean that up.
-    #
-    def parse_switch(switch)
-      uid = switch['ID']
-
-      new_result = {
-        :uid_ems => uid,
-        :name    => switch['Name'],
-        :lans    => process_logical_networks(switch['LogicalNetworks'])
-      }
-
-      return uid, new_result
+      process_collection(vm_networks, :lans) { |vm_network| parse_vm_network(vm_network) }
     end
 
     def parse_vm_network(vm_network)
       uid = vm_network['ID']
       logical_network = vm_network['LogicalNetwork']
 
-      vnet = @inventory['vnets'].select do |vnet|
-        vnet['LogicalNetworks'].find do |vnet_ln|
-          vnet_ln['ID'] == logical_network['ID']
-        end
+      # Connect the VM network to the Logical network via the Virtual network.
+      vnet = @inventory['vnets'].select do |vn|
+        vn['LogicalNetworks'].find { |vnet_ln| vnet_ln['ID'] == logical_network['ID'] }
       end.first
 
       return unless vnet
-
-      switch = @data_index.fetch_path(:switches, vnet['ID'])
+      subnets = process_subnets(vm_network)
 
       new_result = {
-        :ems_ref     => uid,
-        :device_name => vm_network['Name'],
-        :device_type => 'vmnetwork',
-        :lan => {
-          :name    => logical_network['Name'],
-          :uid_ems => logical_network['ID'],
-          :switch  => switch
-        }
+        :name    => vm_network['Name'],
+        :ems_ref => uid,
+        :parent  => vnet,
+        :subnets => subnets
       }
 
       return uid, new_result
+    end
+
+    def process_subnets(vm_network)
+      subnets = vm_network['VMSubnet']
+      return if subnets.blank?
+      array = []
+
+      subnets.each do |subnet|
+        array << {
+          :name    => subnet['Name'],
+          :ems_ref => subnet['ID'],
+          :cidr    => subnet['SubnetVLans'],
+        }
+      end
+
+      return array
     end
 
     def parse_storage_fileshare(volume)

--- a/app/models/manageiq/providers/microsoft/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/refresh_parser.rb
@@ -102,8 +102,9 @@ module ManageIQ::Providers::Microsoft
         end
       end.first
 
-      # TODO: Get this out of @data_index somehow
-      switch = vnet ? Switch.find_by(:uid_ems => vnet['ID']) : nil
+      return unless vnet
+
+      switch = @data_index.fetch_path(:switches, vnet['ID'])
 
       new_result = {
         :ems_ref     => uid,


### PR DESCRIPTION
Currently we collect logical networks, but we do not collect VM network information. This PR adds support for them by adding them to the `guest_devices` table.

Each VM network is associated with a lan (logical network), and so I add that relationship as well. We should then be able to get to the switch (virtual network) via the lan.

Ideally we should create a relationship between a VM and its corresponding VM networks.

Some more information here:

http://windowsitpro.com/hyper-v/understanding-hyper-v-networking-system-center-vmm-2012-r2