### PR TITLE
Validate credentials in raw_connect

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager.rb
@@ -20,11 +20,16 @@ class ManageIQ::Providers::Microsoft::InfraManager < ManageIQ::Providers::InfraM
     @description ||= "Microsoft System Center VMM".freeze
   end
 
-  def self.raw_connect(connect_params)
+  def self.raw_connect(connect_params, validate = false)
     require 'winrm'
 
-    connect_params[:operation_timeout] = 1800
-    WinRM::Connection.new(connect_params)
+    connect_params[:operation_timeout] ||= 1800
+    connect_params[:password] = MiqPassword.try_decrypt(connect_params[:password])
+
+    connect = WinRM::Connection.new(connect_params)
+    return connect unless validate
+
+    connect.shell(:powershell).run('hostname')
   end
 
   def self.auth_url(hostname, port = nil)


### PR DESCRIPTION
The UI is moving towards validating credentials on the queue to allow for validating credentials in separate zones utilizing the `raw_connect` class method, rather than needing to create a temporary EMS for validation.

 For many of the providers, `raw_connect` ensures the credentials are correct. This updates `raw_connect` to not only return a connection but also be able to validate (it will *not* validate by default).

I got the idea to use the power shell run from [here](https://github.com/ManageIQ/manageiq-providers-scvmm/blob/master/app/models/manageiq/providers/microsoft/infra_manager/host.rb#L15) and how credentials are verified in AWS (which is actually a [good example](https://github.com/ManageIQ/manageiq-providers-amazon/pull/264/files#diff-ee01d0d50f62d6e0cf6b5e5b88e2e4c2R50) of what I'm trying to accomplish). Any feedback on this approach and if there would be a better way to validate the credentials is much appreciated!

