### PR TITLE
Fix logger debug statement

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/provision/cloning.rb
@@ -156,9 +156,9 @@ module ManageIQ::Providers::Microsoft::InfraManager::Provision::Cloning
     if results.stdout.blank?
       raise MiqException::MiqProvisionError, results.stderr
     else
-      $scvmm_log.debug(update_vm_script)
+      script = update_vm_script(results.stdout)
+      $scvmm_log.debug(script)
 
-      script  = update_vm_script(results.stdout)
       results = source.ext_management_system.run_powershell_script(script)
 
       if results.stdout.blank?


### PR DESCRIPTION
It seems I never updated this logging statement, which blows up in debug mode, since `update_vm_script` now takes an argument.