### PR TITLE
Use ID property explicitly in update_vm_script

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/provision/cloning.rb
@@ -140,7 +140,7 @@ module ManageIQ::Providers::Microsoft::InfraManager::Provision::Cloning
     <<-PS_SCRIPT
       $vm = ConvertFrom-Json #{json}; \
 
-      Set-SCVirtualMachine -VM $vm \
+      Set-SCVirtualMachine -VM (Get-SCVirtualMachine -ID $vm.ID) \
         #{cpu_ps_script} \
         #{memory_ps_script} | Out-Null; \
 


### PR DESCRIPTION
Trying to pass a raw json string to the `-VM` argument in the `update_vm_script` method won't work. We need to explicitly use the ID property.