### PR TITLE
Fix error in update_vm_script converting from json

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/provision/cloning.rb
@@ -138,7 +138,7 @@ module ManageIQ::Providers::Microsoft::InfraManager::Provision::Cloning
 
   def update_vm_script(json)
     <<-PS_SCRIPT
-      $vm = ConvertFrom-Json #{json}; \
+      $vm = ConvertFrom-Json -InputObject '#{json}'; \
 
       Set-SCVirtualMachine -VM (Get-SCVirtualMachine -ID $vm.ID) \
         #{cpu_ps_script} \


### PR DESCRIPTION
Fix an issue where the update_vm_script would fail to parse the VM ID.

```
+ ... tFrom-Json -InputObject {"ID":"1b5463b3-db6a-4c26-afdb-6f02ea9530cc"}
+
Unexpected token ':"1b5463b3-db6a-4c26-afdb-6f02ea9530cc"' in expression or statement.
    + CategoryInfo          : ParserError: (:) [Invoke-Expression], ParseException
    + FullyQualifiedErrorId : UnexpectedToken,Microsoft.PowerShell.Commands.InvokeExpressionCommand
```