### PR TITLE
[WIP] Fix update_vm_script

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/provision/cloning.rb
@@ -138,12 +138,12 @@ module ManageIQ::Providers::Microsoft::InfraManager::Provision::Cloning
 
   def update_vm_script(json)
     <<-PS_SCRIPT
-      $vm = ConvertFrom-Json #{json}; \
+      $json = ConvertFrom-Json -InputObject '#{json}'; \
+      $vm = Get-SCVirtualMachine -ID $json.ID; \
 
-      Set-SCVirtualMachine -VM (Get-SCVirtualMachine -ID $vm.ID) \
+      Set-SCVirtualMachine -VM $vm \
         #{cpu_ps_script} \
         #{memory_ps_script} | Out-Null; \
-
       #{network_adapter_ps_script}; \
 
       $vm | Select-Object ID | ConvertTo-Json -Compress


### PR DESCRIPTION
Followup to https://github.com/ManageIQ/manageiq-providers-scvmm/pull/29

We need to quote the `json` string.

In addition, we need to get a full `$vm` object before the call to `network_adapter_ps_script` because it needs to pull out the adapter information.

WIP for now, until independently confirmed.