### PR TITLE
Fix VM Subnet Provisioning

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/provision/cloning.rb
@@ -135,21 +135,21 @@ module ManageIQ::Providers::Microsoft::InfraManager::Provision::Cloning
     logical_network = dest_logical_network
     return if logical_network.nil?
 
-    "-LogicalNetwork (Get-SCLogicalNetwork -Name '#{logical_network.name}') "
+    "-LogicalNetwork (Get-SCLogicalNetwork -Name '#{logical_network.name}' -ID '#{logical_network.uid_ems}') "
   end
 
   def vm_network_ps_script
     vm_network = dest_vm_network
     return if vm_network.nil?
 
-    "-VMNetwork (Get-SCVMNetwork -Name '#{vm_network.name}') -VirtualNetwork #{vm_network.switch.name} #{subnet_ps_script} "
+    "-VMNetwork (Get-SCVMNetwork -Name '#{vm_network.name}' -ID '#{vm_network.uid_ems}') -VirtualNetwork #{vm_network.switch.name} #{subnet_ps_script}"
   end
 
   def subnet_ps_script
     subnet = dest_subnet
     return if subnet.nil?
 
-    "-VMSubnet (Get-SCVMSubnet -Name '#{subnet.name}') "
+    "-VMSubnet (Get-SCVMSubnet -Name '#{subnet.name}' | where {$_.VMNetwork.ID -eq '#{subnet.lan.uid_ems}'}) "
   end
 
   def network_adapter_ps_script
@@ -161,7 +161,8 @@ module ManageIQ::Providers::Microsoft::InfraManager::Provision::Cloning
     "$adapter = $vm | SCVirtualNetworkAdapter; \
      Set-SCVirtualNetworkAdapter \
       -VirtualNetworkAdapter $adapter \
-      #{dest_vm_network.nil? ? logical_network_ps_script : vm_network_ps_script}| Out-Null;"
+      #{dest_vm_network.nil? ? logical_network_ps_script : vm_network_ps_script} \
+      -IPv4AddressType Dynamic -IPv6AddressType Dynamic -NoPortClassification | Out-Null;"
   end
 
   def create_vm_script


### PR DESCRIPTION
When provisioning to a VMNetwork + VMSubnet with an IP Pool (required)
and the IP Address Type isn't specified the update script will fail
with:

```
The virtual network adapter ag_test_0002 [MAC: 001DD8B72D67] doesn't have a CA (customer address) assigned from the VMSubnet related IP Pool.
Please assign a CA address from the VMSubnet Address Pool to the virtual network adapter and try again.
```

Adding `IPv4AddressType Dynamic` and `-NoPortClassification` as well as
a few other changes swiped from a VMM script e.g. looking up vm network
by name and id instead of just name, and looking the subnet up by name
and vm network id.