### PR TITLE
missing VMMServer parameter

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/provision/cloning.rb
@@ -169,7 +169,7 @@ module ManageIQ::Providers::Microsoft::InfraManager::Provision::Cloning
     <<-PS_SCRIPT
       Import-Module VirtualMachineManager | Out-Null; \
 
-      $template = Get-SCVMTemplate -Name '#{source.name}'; \
+      $template = Get-SCVMTemplate -Name '#{source.name}' -VMMServer localhost; \
       $vmconfig = New-SCVMConfiguration -VMTemplate $template -Name 'ManageIQConfig-#{dest_name}'; \
       $vmhost   = Get-SCVMHost -ComputerName '#{dest_host}'; \
 


### PR DESCRIPTION
Without this fix the PowerShell script fails to execute.

The -VMMServer is correctly specified in other methods, e.g. ./app/models/manageiq/providers/microsoft/infra_manager.rb but is missing here.