### PR TITLE
Don't report misleading sockets/cores

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/refresh_parser.rb
@@ -402,8 +402,6 @@ module ManageIQ::Providers::Microsoft
 
     def process_vm_hardware(vm)
       {
-        :cpu_sockets          => vm['CPUCount'],
-        :cpu_cores_per_socket => 1,
         :cpu_total_cores      => vm['CPUCount'],
         :guest_os             => vm['OperatingSystem']['Name'],
         :guest_os_full_name   => process_vm_os_description(vm),

--- a/spec/models/manageiq/providers/microsoft/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/microsoft/infra_manager/refresher_spec.rb
@@ -241,8 +241,6 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Refresher do
       :guest_os_full_name   => "Unknown",
       :bios                 => "2c67139b-76e1-40fd-896f-407ee9efc447",
       :cpu_total_cores      => 1,
-      :cpu_sockets          => 1,
-      :cpu_cores_per_socket => 1,
       :annotation           => nil,
       :memory_mb            => 512
     )


### PR DESCRIPTION
SCVMM doesn't return any information regarding how many sockets or
cores_per_socket exist on a VM, only the total number of CPUs.

Currently we report all of these CPUs as sockets with 1 core per socket.
This is misleading since the guest OS typically reports something
different, e.g. CPUCount: 4 => 1 socket x 4 cores and CPUCount: 8 => 2
socket x 4 cores.

Rather than guessing on the socket/cores count we can just set the
cpu_total_cores value and leave the rest blank.

https://bugzilla.redhat.com/show_bug.cgi?id=1514463