### PR TITLE
Fix host maintenance mode

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/refresh_parser.rb
@@ -662,7 +662,11 @@ module ManageIQ::Providers::Microsoft
     end
 
     def lookup_overall_state(overall_state)
-      overall_state.to_s.downcase != 'ok'
+      # OverallState enum:
+      # 0 => Ok
+      # 2 => Needs Attention
+      # 8 => In Maintenance Mode
+      overall_state == 8
     end
 
     def lookup_power_state(power_state_input)

--- a/spec/models/manageiq/providers/microsoft/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/microsoft/infra_manager/refresher_spec.rb
@@ -123,7 +123,8 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Refresher do
       :vmm_version      => "6.3.9600.18623",
       :vmm_product      => "HyperV",
       :power_state      => "on",
-      :connection_state => "connected"
+      :connection_state => "connected",
+      :maintenance      => false,
     )
 
     expect(@host.operating_system).to have_attributes(


### PR DESCRIPTION
Host OverallState is an integer but was being compared to "ok" so all
SCVMM hosts were being treated as if they were in maintenance mode.

~~TODO: need to test on 2012 and 2016~~
Tested on 2012 and 2016, OveralState 0 means "Ok", 2 means "Needs Attention", and 8 means "In Maintenance Mode".
Thoughts on switching this from `!= 0` to `== 8` ?

https://bugzilla.redhat.com/show_bug.cgi?id=1514986