### PR TITLE
Added supported_catalog_types

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager.rb
@@ -95,6 +95,10 @@ class ManageIQ::Providers::Microsoft::InfraManager < ManageIQ::Providers::InfraM
     true
   end
 
+  def supported_catalog_types
+    %w(microsoft)
+  end
+
   def vm_start(vm, _options = {})
     case vm.power_state
     when "suspended" then execute_power_operation("Resume", vm.uid_ems)

--- a/spec/models/manageiq/providers/microsoft/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/microsoft/infra_manager_spec.rb
@@ -95,4 +95,12 @@ describe ManageIQ::Providers::Microsoft::InfraManager do
       described_class.raw_connect(params)
     end
   end
+
+  context 'catalog types' do
+    let(:ems) { FactoryGirl.create(:ems_microsoft) }
+
+    it "#supported_catalog_types" do
+      expect(ems.supported_catalog_types).to eq(%w(microsoft))
+    end
+  end
 end


### PR DESCRIPTION
For service catalog each provider needs to provide the supported catalog types

This is needed for PR https://github.com/ManageIQ/manageiq/pull/16559