### PR TITLE
Migrate model display names from locale/en.yml to plugin

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager.rb
@@ -158,6 +158,10 @@ class ManageIQ::Providers::Microsoft::InfraManager < ManageIQ::Providers::InfraM
     raise
   end
 
+  def self.display_name(number = 1)
+    n_('Infrastructure Provider (Microsoft)', 'Infrastructure Providers (Microsoft)', number)
+  end
+
   private
 
   def execute_power_operation(cmdlet, vm_uid_ems, *parameters)

--- a/app/models/manageiq/providers/microsoft/infra_manager/host.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/host.rb
@@ -31,4 +31,8 @@ class ManageIQ::Providers::Microsoft::InfraManager::Host < ::Host
     user, pass = auth_user_pwd(auth_type)
     MiqScvmmVmSSAInfo.new(hostname, user, pass)
   end
+
+  def self.display_name(number = 1)
+    n_('Host (Microsoft)', 'Hosts (Microsoft)', number)
+  end
 end

--- a/app/models/manageiq/providers/microsoft/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/vm.rb
@@ -33,4 +33,8 @@ class ManageIQ::Providers::Microsoft::InfraManager::Vm < ManageIQ::Providers::In
   def has_proxy?
     true
   end
+
+  def self.display_name(number = 1)
+    n_('Virtual Machine (Microsoft)', 'Virtual Machines (Microsoft)', number)
+  end
 end


### PR DESCRIPTION
This is a continuation of the work started in https://github.com/ManageIQ/manageiq/pull/16596 where we want to migrate display model names from locale/en.yml into particular models, where we'll use standard gettext. Main goal here is to make this one aspect of our application pluggable.

Core PR: https://github.com/ManageIQ/manageiq/pull/16836