### PR TITLE
Handle nil ems inventory from insufficient privileges credential issues

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/refresh_parser.rb
@@ -22,7 +22,7 @@ module ManageIQ::Providers::Microsoft
       script = IO.read(INVENTORY_SCRIPT)
       @inventory = ManageIQ::Providers::Microsoft::InfraManager.execute_powershell_json(@connection, script)
 
-      if @inventory.empty?
+      if @inventory.empty? || @inventory['ems'].empty?
         $scvmm_log.warn("#{log_header}...Empty inventory set returned from SCVMM.")
         return
       end


### PR DESCRIPTION
If the provided credentials do not have enough permissions to access the
VMM management server the following is printed to stderr:
"You cannot contact the VMM management server.
The credentials provided have insufficient privileges on localhost."

but an inventory hash is still returned that contains:
```
{
  "ems": nil,
  "vms": [],
  "hosts": [],
  ...
}
```

before continuing with the refresh this checks if the ems data returned
is blank to catch these issues.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1549667