### PR TITLE
Check connection to VMM when verifying credentials

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager/ps_scripts/test_connection.ps1
+++ b/app/models/manageiq/providers/microsoft/infra_manager/ps_scripts/test_connection.ps1
@@ -1,0 +1,12 @@
+import-module virtualmachinemanager
+
+$hash = @{}
+
+$ems = Get-SCVMMServer -ComputerName localhost |
+  Select @{name='Guid';expression={$_.ManagedComputer.ID -As [string]}},
+    @{name='Version';expression={$_.ServerInterfaceVersion -As [string]}}
+
+$hash["ems"] = $ems
+
+# Maximum depth is 4 due to VMHostNetworkAdapters
+ConvertTo-Json -InputObject $hash -Depth 4 -Compress


### PR DESCRIPTION
When verifying credentials connect to the VMM service to confirm that
the credentials are privileged enough.

With this now verify fails with:
`Credential validation was not successful: Unable to connect: You cannot contact the VMM management server. The credentials provided have insufficient privileges on DEV-SCVMM2K12\Administrator.`

![screenshot from 2018-03-23 12-12-40](https://user-images.githubusercontent.com/12851112/37840653-0ead9138-2e94-11e8-9f24-0e546184d2cd.png)

https://bugzilla.redhat.com/show_bug.cgi?id=1549667