### PR TITLE
Add parent_id to the ActiveRecord select filter

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/provision_workflow.rb
@@ -43,7 +43,7 @@ class ManageIQ::Providers::Microsoft::InfraManager::ProvisionWorkflow < ::MiqPro
   end
 
   def load_hosts_vlans(hosts, vlans)
-    lans_for_hosts = Lan.distinct.select(:id, :switch_id, :uid_ems, :name)
+    lans_for_hosts = Lan.distinct.select(:id, :switch_id, :uid_ems, :name, :parent_id)
                         .includes(:parent)
                         .joins(:switch => :host_switches)
                         .where(:host_switches => {:host_id => hosts.map(&:id)})

--- a/spec/models/manageiq/providers/microsoft/infra_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/microsoft/infra_manager/provision_workflow_spec.rb
@@ -16,6 +16,21 @@ describe ManageIQ::Providers::Microsoft::InfraManager::ProvisionWorkflow do
     described_class.new({}, admin.userid)
   end
 
+  describe "#load_hosts_vlans" do
+    let(:host)        { FactoryGirl.create(:host_with_ref, :switches => [switch]) }
+    let(:switch)      { FactoryGirl.create(:switch) }
+    let!(:lan_parent) { FactoryGirl.create(:lan, :switch => switch) }
+    let!(:lan)        { FactoryGirl.create(:lan, :parent => lan_parent, :switch => switch) }
+
+    it "includes parent lans" do
+      stub_dialog
+      prov_workflow = described_class.new({}, admin.userid)
+      lan_for_host = prov_workflow.load_hosts_vlans([host], {}).detect(&:parent)
+      expect(lan_for_host).to be_a(Lan)
+      expect(lan_for_host.parent).to be_a(Lan)
+    end
+  end
+
   describe "#make_request" do
     let(:alt_user) { FactoryGirl.create(:user_with_group) }
     it "creates and update a request" do


### PR DESCRIPTION
Add `:parent_id` to the `.select` filter to allow the `.includes` method to pull in `:parent` associations
``` 
lans_for_hosts = Lan.distinct.select(:id, :switch_id, :uid_ems, :name, :parent_id)
                        .includes(:parent)
                        .joins(:switch => :host_switches)
                        .where(:host_switches => {:host_id => hosts.map(&:id)})
                        .where(:switches => {:shared => [nil, false]})
```

https://bugzilla.redhat.com/show_bug.cgi?id=1613023