### PR TITLE
Handle possibility of no associated vnet

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/refresh_parser.rb
@@ -433,7 +433,7 @@ module ManageIQ::Providers::Microsoft
       [
         {
           :hostname  => process_computer_name(vm['ComputerName']),
-          :ipaddress => vm['VirtualNetworkAdapters'].map{ |nic| nic['IPv4Addresses'] }.first
+          :ipaddress => Array(vm['VirtualNetworkAdapters']).map{ |nic| nic['IPv4Addresses'] }.first
         }
       ]
     end


### PR DESCRIPTION
Currently if a VM has no associated virtual network adapter(s), then the refresh parser will raise an error when it tries to access that property and call `.map` on a nil value.

This PR forces an array context via an `Array()` call prior to calling `.map` so that it will simply return nil if there's no associated vnet. We do this in several other places within the parser already.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1646954