### PR TITLE
Remove references to MiqPassword

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager.rb
@@ -25,7 +25,7 @@ class ManageIQ::Providers::Microsoft::InfraManager < ManageIQ::Providers::InfraM
     require 'winrm'
 
     connect_params[:operation_timeout] ||= 1800
-    connect_params[:password] = MiqPassword.try_decrypt(connect_params[:password])
+    connect_params[:password] = ManageIQ::Password.try_decrypt(connect_params[:password])
 
     connect = WinRM::Connection.new(connect_params)
     return connect unless validate

--- a/app/models/manageiq/providers/microsoft/infra_manager/vm_or_template_shared/scanning.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/vm_or_template_shared/scanning.rb
@@ -64,7 +64,7 @@ module ManageIQ::Providers::Microsoft::InfraManager::VmOrTemplateShared::Scannin
       ems_text = "#{ems_connect_type}(#{use_broker ? 'via broker' : 'directly'}):#{miq_vm_host[:address]}"
       log_text = "#{log_header}: Connection to [#{ems_text}]"
       $log.info "#{log_header}: Connecting to [#{ems_text}] for VM:[#{vm_name}]"
-      password = MiqPassword.decrypt(miq_vm_host[:password])
+      password = ManageIQ::Password.decrypt(miq_vm_host[:password])
       miq_vm_host[:username] = miq_vm_host[:domain] + "\\" + miq_vm_host[:username] unless miq_vm_host[:domain].nil?
 
       begin

--- a/spec/models/manageiq/providers/microsoft/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/microsoft/infra_manager_spec.rb
@@ -99,10 +99,10 @@ describe ManageIQ::Providers::Microsoft::InfraManager do
     end
 
     it "decrypts the password" do
-      password = MiqPassword.encrypt("password")
+      password = ManageIQ::Password.encrypt("password")
       params = { :endpoint => "http://host2:5985/wsman", :user => "user", :password => password }
 
-      expect(MiqPassword).to receive(:try_decrypt).with(password).and_return("password")
+      expect(ManageIQ::Password).to receive(:try_decrypt).with(password).and_return("password")
 
       described_class.raw_connect(params)
     end


### PR DESCRIPTION
@agrare @djberg96 Please review.  This gets us closer to removing MiqPassword from manageiq-gems-pending.

cc @jrafanie 