### PR TITLE
Default to graph refresh

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -6,7 +6,7 @@
       :event_groups:
 :ems_refresh:
   :scvmm:
-    :inventory_object_refresh: false
+    :inventory_object_refresh: true
 :http_proxy:
   :scvmm:
     :host:


### PR DESCRIPTION
With the goal to deprecate/delete classic refresh we want to move to
default to graph refresh for all providers.