### PR TITLE
Fix an issue building host_guest_device cd drive

### DIFF
--- a/app/models/manageiq/providers/microsoft/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/microsoft/inventory/parser/infra_manager.rb
@@ -186,6 +186,7 @@ class ManageIQ::Providers::Microsoft::Inventory::Parser::InfraManager < ManageIQ
     data["DVDDriveList"].each do |dvd|
       persister.host_guest_devices.build(
         :hardware        => hardware,
+        :uid_ems         => dvd,
         :device_type     => "cdrom",
         :present         => true,
         :controller_type => "IDE",


### PR DESCRIPTION
A uid_ems wasn't being passed to the host_guest_device.find_or_build
method leading to the following error:

```
Error occured: Needed find_or_build_by keys are: [:hardware, :uid_ems], data provided: {:hardware=>InventoryObject:('7785cad0-b2d6-451b-b4a5-17cdde29d91a', InventoryCollection:<Hardware>), :device_type=>"cdrom", :present=>true, :controller_type=>"IDE", :mode=>"persistent", :filename=>"D"}
```