### PR TITLE
Disable support for restart/shutdown if VM is off

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/vm.rb
@@ -4,8 +4,14 @@ class ManageIQ::Providers::Microsoft::InfraManager::Vm < ManageIQ::Providers::In
   supports_not :migrate, :reason => _("Migrate operation is not supported.")
   supports_not :publish
 
-  supports :reboot_guest
-  supports :shutdown_guest
+  supports :reboot_guest do
+    unsupported_reason_add(:reboot_guest, _('The VM is not powered on')) unless current_state == 'on'
+  end
+
+  supports :shutdown_guest do
+    unsupported_reason_add(:shutdown_guest, _('The VM is not powered on')) unless current_state == 'on'
+  end
+
   supports :reset do
     unsupported_reason_add(:reset, _('The VM is not powered on')) unless current_state == 'on'
   end


### PR DESCRIPTION
If a VM is not running it cannot be restarted or shutdown.

![Screenshot from 2019-07-18 09-05-32](https://user-images.githubusercontent.com/12851112/61459687-4ce8ca80-a93b-11e9-9c42-c93728ffd72c.png)


Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1724062