### PR TITLE
Fix the SCVMM template type, was just MiqTemplate

### DIFF
--- a/app/models/manageiq/providers/microsoft/inventory/persister/infra_manager.rb
+++ b/app/models/manageiq/providers/microsoft/inventory/persister/infra_manager.rb
@@ -14,7 +14,7 @@ class ManageIQ::Providers::Microsoft::Inventory::Persister::InfraManager < Manag
     add_collection(infra, :host_storages)
     add_collection(infra, :host_switches)
     add_collection(infra, :lans)
-    add_collection(infra, :miq_templates)
+    add_collection(infra, :miq_templates, :model_class => ManageIQ::Providers::Microsoft::InfraManager::Template)
     add_collection(infra, :networks)
     add_collection(infra, :operating_systems)
     add_collection(infra, :snapshots)

--- a/spec/models/manageiq/providers/microsoft/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/microsoft/infra_manager/refresher_spec.rb
@@ -41,6 +41,7 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Refresher do
           assert_specific_vm_network
           assert_specific_subnet
           assert_specific_vm
+          assert_specific_template
           assert_specific_guest_devices
           assert_specific_snapshot
           assert_specific_storage
@@ -292,6 +293,17 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Refresher do
     )
 
     # TODO: Add "Stored" status value in DB. This is a VM that has been provisioned but not deployed
+  end
+
+  def assert_specific_template
+    template = @ems.miq_templates.find_by(:ems_ref => "3184d261-3226-490c-bb2f-010d547059f5")
+    expect(template).to have_attributes(
+      :name            => "miq-nightly-201709012000",
+      :uid_ems         => "3184d261-3226-490c-bb2f-010d547059f5",
+      :power_state     => "never",
+      :type            => "ManageIQ::Providers::Microsoft::InfraManager::Template",
+      :raw_power_state => "never"
+    )
   end
 
   def assert_specific_snapshot


### PR DESCRIPTION
The auto-model-class feature of the persister builder wasn't picking up
the class correctly because it was looking for
ManageIQ::Providers::Microsoft::InfraManager::MiqTemplate instead of
...InfraManager::Template.

This caused the templates that got created to have the base model type
of MiqTemplate.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1732349