### PR TITLE
Ignore powershell.log files after running specs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /doc/
 /pkg/
 /spec/reports/
+/spec/tools/scvmm_data/powershell.log*
 /tmp/
 
 /config/settings.local.yml


### PR DESCRIPTION
When running the refresh specs you get a bunch of untracked files:
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	spec/tools/scvmm_data/powershell.log.20190725
	spec/tools/scvmm_data/powershell.log.20190725.1
	spec/tools/scvmm_data/powershell.log.20190725.2