### PR TITLE
Remove gettext initiliazer & friends

### DIFF
--- a/config/initializers/gettext.rb
+++ b/config/initializers/gettext.rb
@@ -1,5 +1,0 @@
-Vmdb::Gettext::Domains.add_domain(
-  'ManageIQ_Providers_Scvmm',
-  ManageIQ::Providers::Scvmm::Engine.root.join('locale').to_s,
-  :po
-)

--- a/spec/i18n/placeholders_spec.rb
+++ b/spec/i18n/placeholders_spec.rb
@@ -1,3 +1,0 @@
-describe :placeholders do
-  include_examples :placeholders, ManageIQ::Providers::Scvmm::Engine.root.join('locale').to_s
-end

--- a/zanata.xml
+++ b/zanata.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<config xmlns="http://zanata.org/namespace/config/">
-  <url>https://translate.zanata.org/</url>
-  <project>manageiq-providers-scvmm</project>
-  <project-version>master</project-version>
-  <project-type>gettext</project-type>
-</config>


### PR DESCRIPTION
* there's no need for the plugin to initialize its own catalog anymore
* remove `zanata.xml` (we use transifex now)
* remove placeholders test (not needed anymore)