### PR TITLE
Fix VMDBLogger initialize for ruby 2.7

### DIFF
--- a/spec/models/manageiq/providers/microsoft/infra_manager/powershell_spec.rb
+++ b/spec/models/manageiq/providers/microsoft/infra_manager/powershell_spec.rb
@@ -40,7 +40,7 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Powershell do
     before(:each) do
       $original_scvmm_log = $scvmm_log.clone
       @log_file = ManageIQ::Providers::Scvmm::Engine.root.join("spec", "tools", "scvmm_data", "powershell.log")
-      $scvmm_log = VMDBLogger.new(@log_file, :error, "<POWERSHELL>")
+      $scvmm_log = VMDBLogger.new(@log_file, :level => :error, :progname => "<POWERSHELL>")
     end
 
     after(:each) do


### PR DESCRIPTION
Ruby 2.7 is more strict about the arguments and keywords passed to initailize

```
  4) ManageIQ::Providers::Microsoft::InfraManager::Powershell log_dos_error_results does not write empty strings to the log
     Failure/Error: $scvmm_log = VMDBLogger.new(@log_file, :error, "<POWERSHELL>")
     
     ArgumentError:
       invalid :shift_age :error, should be daily, weekly, monthly, or everytime
```

https://travis-ci.com/github/ManageIQ/manageiq-cross_repo-tests/jobs/330698084#L3871-L3875