### PR TITLE
Make the default credentials required in the provider DDF

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager.rb
@@ -39,6 +39,7 @@ class ManageIQ::Providers::Microsoft::InfraManager < ManageIQ::Providers::InfraM
             :id                     => 'endpoints.default.valid',
             :name                   => 'endpoints.default.valid',
             :skipSubmit             => true,
+            :isRequired             => true,
             :validationDependencies => %w[type zone_id],
             :fields                 => [
               {


### PR DESCRIPTION
The default behavior for the `async-credentials` component is [changing to be optional](https://github.com/ManageIQ/manageiq-ui-classic/pull/7347), so it has to be explicitly marked as required here.