### PR TITLE
Fix unused exception handlers, unused variable

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/scanning/job.rb
@@ -64,6 +64,7 @@ class ManageIQ::Providers::Microsoft::InfraManager::Scanning::Job < VmScan
         rescue Timeout::Error
           msg = "Request to delete snapshot timed out"
           _log.error(msg)
+          return
         rescue => err
           _log.error(err.to_s)
           return


### PR DESCRIPTION
This PR addresses a couple issues spotted by the linter.

Namely shadowed exceptions that would never be caught (same as https://github.com/ManageIQ/manageiq-providers-vmware/pull/682, which has a more detailed explanation), as well as the use of `log_start_user_event_message` instead of the useless assignment that we have now.