### PR TITLE
Replace URI.decode with URI.decode_www_form_component

### DIFF
--- a/.rubocop_local.yml
+++ b/.rubocop_local.yml
@@ -3,3 +3,5 @@ Style/GlobalVars:
 
   # Loggers
   - $scvmm_log
+Lint/RescueException:
+  Enabled: false

--- a/app/models/manageiq/providers/microsoft/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/provision/cloning.rb
@@ -36,7 +36,7 @@ module ManageIQ::Providers::Microsoft::InfraManager::Provision::Cloning
 
   def dest_mount_point
     name = dest_datastore.name.scan(MT_POINT_REGEX).flatten.pop
-    URI.decode(name.to_s).tr('/', '\\')
+    URI.decode_www_form_component(name.to_s).tr('/', '\\')
   end
 
   def dest_logical_network


### PR DESCRIPTION
This PR fixes the last of the linter warnings, replacing the long-deprecated `URI.decode` with `URI.decode_www_form_component`. There is at least a little test coverage on that method, and it passes with this change.

I've also disabled the `RescueException` warning since changing those would risk too much breakage IMO.

For more info: https://docs.knapsackpro.com/2020/uri-escape-is-obsolete-percent-encoding-your-query-string