### PR TITLE
Convert `supports_#{op}?` to `supports?(op)`

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager/template.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/template.rb
@@ -3,7 +3,7 @@ class ManageIQ::Providers::Microsoft::InfraManager::Template < ManageIQ::Provide
 
   supports :provisioning do
     if ext_management_system
-      unsupported_reason_add(:provisioning, ext_management_system.unsupported_reason(:provisioning)) unless ext_management_system.supports_provisioning?
+      unsupported_reason_add(:provisioning, ext_management_system.unsupported_reason(:provisioning)) unless ext_management_system.supports?(:provisioning)
     else
       unsupported_reason_add(:provisioning, _('not connected to ems'))
     end

--- a/app/models/manageiq/providers/microsoft/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/vm.rb
@@ -6,21 +6,21 @@ class ManageIQ::Providers::Microsoft::InfraManager::Vm < ManageIQ::Providers::In
   supports_not :publish
 
   supports :reboot_guest do
-    unsupported_reason_add(:reboot_guest, unsupported_reason(:control)) unless supports_control?
+    unsupported_reason_add(:reboot_guest, unsupported_reason(:control)) unless supports?(:control)
     unless current_state == 'on'
       unsupported_reason_add(:reboot_guest, _('The VM is not powered on'))
     end
   end
 
   supports :shutdown_guest do
-    unsupported_reason_add(:shutdown_guest, unsupported_reason(:control)) unless supports_control?
+    unsupported_reason_add(:shutdown_guest, unsupported_reason(:control)) unless supports?(:control)
     unless current_state == 'on'
       unsupported_reason_add(:shutdown_guest, _('The VM is not powered on'))
     end
   end
 
   supports :reset do
-    unsupported_reason_add(:reset, unsupported_reason(:control)) unless supports_control?
+    unsupported_reason_add(:reset, unsupported_reason(:control)) unless supports?(:control)
     unless current_state == 'on'
       unsupported_reason_add(:reset, _('The VM is not powered on'))
     end

--- a/spec/models/manageiq/providers/microsoft/infra_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/microsoft/infra_manager/vm_spec.rb
@@ -41,13 +41,13 @@ describe ManageIQ::Providers::Microsoft::InfraManager::Vm do
     it "is available when powered on" do
       vm.update(:raw_power_state => powered_on)
       expect(vm.current_state).to eql('on')
-      expect(vm.supports_reset?).to be_truthy
+      expect(vm.supports?(:reset)).to be_truthy
     end
 
     it "is not available when powered off" do
       vm.update(:raw_power_state => powered_off)
       expect(vm.current_state).to eql('off')
-      expect(vm.supports_reset?).to be_falsy
+      expect(vm.supports?(:reset)).to be_falsy
       expect(vm.unsupported_reason(:reset)).to eql('The VM is not powered on')
     end
   end


### PR DESCRIPTION
Additionally, convert method definitions such as

```ruby
def supports_port?
  true
end
```

to

```ruby
supports :port
```