### PR TITLE
Adjust empty/initial values for select fields in DDF schemas

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager.rb
@@ -51,13 +51,14 @@ class ManageIQ::Providers::Microsoft::InfraManager < ManageIQ::Providers::InfraM
                 :validate   => [{:type => "required"}]
               },
               {
-                :component  => "select",
-                :id         => "endpoints.default.security_protocol",
-                :name       => "endpoints.default.security_protocol",
-                :label      => _("Security Protocol"),
-                :isRequired => true,
-                :validate   => [{:type => "required"}],
-                :options    => [
+                :component    => "select",
+                :id           => "endpoints.default.security_protocol",
+                :name         => "endpoints.default.security_protocol",
+                :label        => _("Security Protocol"),
+                :isRequired   => true,
+                :initialValue => 'ssl',
+                :validate     => [{:type => "required"}],
+                :options      => [
                   {
                     :label => _("SSL"),
                     :value => "ssl",


### PR DESCRIPTION
Because carbon has four different dropdowns, the DDF schemas need to have explicit initialValue or includeEmpty settings in order to make the form validation work.

@miq-bot assign @agrare