### PR TITLE
Handle missing VM VMCPath

### DIFF
--- a/app/models/manageiq/providers/microsoft/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/microsoft/inventory/parser/infra_manager.rb
@@ -287,7 +287,7 @@ class ManageIQ::Providers::Microsoft::Inventory::Parser::InfraManager < ManageIQ
       host_id    = host&.dig("ID")
       cluster_id = host&.dig("Cluster", "ID")
 
-      mount_point = data["VMCPath"].match(drive_letter).to_s
+      mount_point = data["VMCPath"]&.match(drive_letter)&.to_s
       storage_id  = collector.storage_id_by_host_name_and_mount_point.dig(data["HostName"], mount_point) if mount_point
 
       vm = persister.vms.build(


### PR DESCRIPTION
Prevent an exception if a VM has a nil VMCPath:
```
[----] E, [2021-03-07T18:36:50.420964 #2699:2ac2b84f85bc] ERROR -- : [NoMethodError]: undefined method `match' for nil:NilClass  Method:[block (2 levels) in <class:LogProxy>]
[----] E, [2021-03-07T18:36:50.421030 #2699:2ac2b84f85bc] ERROR -- : /opt/rh/cfme-gemset/bundler/gems/cfme-providers-scvmm-5aa8b0b277c5/app/models/manageiq/providers/microsoft/inventory/parser/infra_manager.rb:2
87:in `block in parse_vms'
/opt/rh/cfme-gemset/bundler/gems/cfme-providers-scvmm-5aa8b0b277c5/app/models/manageiq/providers/microsoft/inventory/parser/infra_manager.rb:282:in `each'
/opt/rh/cfme-gemset/bundler/gems/cfme-providers-scvmm-5aa8b0b277c5/app/models/manageiq/providers/microsoft/inventory/parser/infra_manager.rb:282:in `parse_vms'
/opt/rh/cfme-gemset/bundler/gems/cfme-providers-scvmm-5aa8b0b277c5/app/models/manageiq/providers/microsoft/inventory/parser/infra_manager.rb:14:in `parse'
/var/www/miq/vmdb/app/models/manageiq/providers/inventory.rb:42:in `block in parse'
/var/www/miq/vmdb/app/models/manageiq/providers/inventory.rb:39:in `each'
/var/www/miq/vmdb/app/models/manageiq/providers/inventory.rb:39:in `parse'
```

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1936192