### PR TITLE
supports :catalog

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager.rb
@@ -15,6 +15,7 @@ class ManageIQ::Providers::Microsoft::InfraManager < ManageIQ::Providers::InfraM
 
   include_concern "Powershell"
 
+  supports :catalog
   supports :provisioning
 
   def self.ems_type


### PR DESCRIPTION
part of https://github.com/ManageIQ/manageiq/pull/21505

```diff
- responds_to?(:catalog_type)
+ supports?(:catalog)
```
