### PR TITLE
Remove the cron schedule from actions since this plugin is removed

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,8 +4,6 @@ on:
   push:
   pull_request:
   workflow_dispatch:
-  schedule:
-  - cron: 0 0 * * *
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Until this repo is archived (that is, we don't release branches that use this repo anymore), this commit stops building master on a schedule.

@agrare Please review. (I get failure messages every time this runs 😆 )

This PR is expected to fail, because it has been removed from master (this is why I'm getting rid of the cron, because it will always fail)